### PR TITLE
Implement byte-limited queue

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -300,6 +300,33 @@ describe("BetterWebSocket", () => {
 
       expect(ws.getQueuedMessageCount()).toBe(3);
     });
+
+    test("should respect max queue byte size", () => {
+      const options: BetterWebSocketOptions = {
+        maxQueueSize: 10,
+        maxQueueBytes: 10,
+      };
+
+      ws = new BetterWebSocket(`ws://localhost:9999`, undefined, options);
+
+      ws.send("1234");
+      ws.send("5678");
+      ws.send("90ab"); // total 12 bytes, should drop the first
+
+      expect(ws.getQueuedMessageCount()).toBe(2);
+      expect(ws.bufferedAmount).toBeLessThanOrEqual(10);
+    });
+
+    test("should error when single message exceeds byte size limit", () => {
+      const options: BetterWebSocketOptions = {
+        maxQueueSize: 2,
+        maxQueueBytes: 5,
+      };
+
+      ws = new BetterWebSocket(`ws://localhost:9999`, undefined, options);
+
+      expect(() => ws.send("toolong")).toThrow();
+    });
   });
 
   describe("URL Fallback", () => {

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -1,0 +1,72 @@
+export interface Sized {
+  size: number;
+}
+
+export class RingBufferQueue<T extends Sized> {
+  private buffer: (T | undefined)[];
+  private head = 0;
+  private tail = 0;
+  private count = 0;
+  private totalBytes = 0;
+
+  constructor(private maxCount: number, private maxBytes: number) {
+    this.buffer = new Array(maxCount);
+  }
+
+  get length(): number {
+    return this.count;
+  }
+
+  get byteSize(): number {
+    return this.totalBytes;
+  }
+
+  push(item: T): void {
+    if (item.size > this.maxBytes) {
+      throw new Error("Item size exceeds queue byte limit");
+    }
+
+    while (this.count >= this.maxCount || this.totalBytes + item.size > this.maxBytes) {
+      this.shift();
+    }
+
+    this.buffer[this.tail] = item;
+    this.tail = (this.tail + 1) % this.maxCount;
+    if (this.count < this.maxCount) {
+      this.count++;
+    }
+    this.totalBytes += item.size;
+  }
+
+  shift(): T | undefined {
+    if (this.count === 0) return undefined;
+    const item = this.buffer[this.head];
+    this.buffer[this.head] = undefined;
+    this.head = (this.head + 1) % this.maxCount;
+    this.count--;
+    if (item) {
+      this.totalBytes -= item.size;
+    }
+    return item;
+  }
+
+  clear(): void {
+    this.buffer = new Array(this.maxCount);
+    this.head = 0;
+    this.tail = 0;
+    this.count = 0;
+    this.totalBytes = 0;
+  }
+
+  values(): T[] {
+    const items: T[] = [];
+    for (let i = 0; i < this.count; i++) {
+      const idx = (this.head + i) % this.maxCount;
+      const item = this.buffer[idx];
+      if (item !== undefined) {
+        items.push(item);
+      }
+    }
+    return items;
+  }
+}


### PR DESCRIPTION
## Summary
- add `RingBufferQueue` for efficient queueing with byte tracking
- support `maxQueueBytes` in `BetterWebSocket`
- use queue for buffering messages
- test byte limit overflow behaviour

## Testing
- `bun test --silent`